### PR TITLE
Fixes Feature migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## 1.0.0 - 2025-04-12
+## 1.0.2 | 2025-04012
+
+- Fixes tenant name in create feature migration
+
+## 1.0.0 | 2025-04-12
 
 - Managing features
 - Querying features
 
 
-## 0.1.0 - 2025-04-11
+## 0.1.0 | 2025-04-11
 
 - Initial release

--- a/lib/generators/togglefy/templates/create_features.rb
+++ b/lib/generators/togglefy/templates/create_features.rb
@@ -4,7 +4,7 @@ class CreateTogglefyFeatures < ActiveRecord::Migration[8.0]
       t.string :name, null: false
       t.string :identifier, null: false
       t.string :description
-      t.string :tenant
+      t.string :tenant_id
       t.string :group
       t.string :environment
       t.integer :status, default: 0, null: false

--- a/lib/togglefy/version.rb
+++ b/lib/togglefy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Togglefy
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
# Context
The feature migration was with the tenant column written wrong.

It should be `tenant_id` and not `tenant`.

# Resolution
Changed the name