### PR TITLE
Fix migrations numbers

### DIFF
--- a/lib/generators/togglefy/install_generator.rb
+++ b/lib/generators/togglefy/install_generator.rb
@@ -14,6 +14,7 @@ module Togglefy
 
       def copy_migrations
         migration_template "create_features.rb", "db/migrate/create_togglefy_features.rb"
+        sleep 1
         migration_template "create_feature_assignments.rb", "db/migrate/create_togglefy_feature_assignments.rb"
       end
     end

--- a/lib/generators/togglefy/install_generator.rb
+++ b/lib/generators/togglefy/install_generator.rb
@@ -14,7 +14,7 @@ module Togglefy
 
       def copy_migrations
         migration_template "create_features.rb", "db/migrate/create_togglefy_features.rb"
-        sleep 1
+        sleep 1.5
         migration_template "create_feature_assignments.rb", "db/migrate/create_togglefy_feature_assignments.rb"
       end
     end


### PR DESCRIPTION
# Context
Migrations were being generated with the same number.

# Resolution
* Added a sleep of 1 second between generating migrations to ensure a different number.