### PR TITLE
Chaining and Deprecate Featureable method

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ After that, the next steps are also pretty simple.
 
 Add the following to your model that will have a relation with the features. It can be an `User`, `Account` or something you decide:
 ```ruby
-include Togglefy::Featureable
+include Togglefy::Assignable
 ```
 
-This will add the relationship between Togglefy's models and yours. Yours will be referred to as **assignable** throughout this documentation. If you want to check it in the source code, you can find it here: `lib/togglefy/featureable.rb` inside de `included` block.
+This will add the relationship between Togglefy's models and yours. Yours will be referred to as **assignable** throughout this documentation. If you want to check it in the source code, you can find it here: `lib/togglefy/assignable.rb` inside de `included` block.
 
 With that, everything is ready to use **Togglefy**, welcome!
 
@@ -107,7 +107,7 @@ status: "inactive"
 
 As you can see, the `Togglefy::Feature` also has a status and it is default to `inactive`. You can change this during creation.
 
-The status holds the `inactive` or `active` values. This status is not to define if a assignable (any model that has the `include Togglefy::Featureable`) either has ou hasn't a feature, but to decide if this feature is available in the entire system.
+The status holds the `inactive` or `active` values. This status is not to define if a assignable (any model that has the `include Togglefy::Assignable`) either has ou hasn't a feature, but to decide if this feature is available in the entire system.
 
 It's up to you to define how you will implement it.
 
@@ -128,7 +128,7 @@ You can change the status by:
 ### Managing Assignables <-> Features
 Now that we know how to create features, let's check how we can manage them.
 
-An assignable has some direct methods thanks to the `include Togglefy::Featureable`, which are (and let's use an user as an example of an assignable):
+An assignable has some direct methods thanks to the `include Togglefy::Assignable`, which are (and let's use an user as an example of an assignable):
 
 ```ruby
 user.has_feature?(:super_powers) # Checks if user has a single feature
@@ -183,7 +183,7 @@ You can send `nil` values too, like:
 ```ruby
 Togglefy.for_tenant(nil) # This will query me all Togglefy::Features with tenant_id nil
 
-Togglefy.for_filters(filters: {group: :admin, environment: :nil, tenant_id: nil})
+Togglefy.for_filters(filters: {group: :admin, environment: nil, tenant_id: nil})
 ```
 
 There's also another way to filter for `nil` values:
@@ -252,7 +252,7 @@ Togglefy.for_filters(filter: {env: :production})
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ include Togglefy::Assignable
 
 This will add the relationship between Togglefy's models and yours. Yours will be referred to as **assignable** throughout this documentation. If you want to check it in the source code, you can find it here: `lib/togglefy/assignable.rb` inside de `included` block.
 
+Old versions (`<= 1.0.2`) had the `Featureable` instead of the `Assignable`. The `Featureable` is now deprecated. You can still use it and it won't impact old users, but we highly recommend you to use the `Assignable` as it is semantically more accurate about what it does.
+
 With that, everything is ready to use **Togglefy**, welcome!
 
 ### Creating Features

--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ Togglefy.for(assignable).disable(:super_powers) # Disables/removes a feature fro
 Togglefy.for(assignable).clear # Clears all features from an assignable
 ```
 
+You can also supercharge it by chaining methods, like:
+
+```ruby
+# Instead of doing this:
+Togglefy.for(assignable).disable(:alpha_access)
+Togglefy.for(assignable).enable(:beta_access)
+
+# You can go something like this:
+Togglefy.for(assignable).disable(:alpha_access).enable(:beta_access)
+```
+
 This second method may look strange, but it's the default used by the gem and you will see that right now!
 
 ### Querying Features
@@ -179,6 +190,22 @@ Togglefy.for_filters(filters: {group: :admin, environment: :production})
 ```
 
 This will query me all `Togglefy::Feature`s that belongs to group admin and the production environment.
+
+The `Togglefy.for_filters` can have the following filters:
+
+```ruby
+filters: {
+  group:,
+  role:, # Acts as a group, explained in the Aliases section
+  environment:,
+  env:, # Acts as a group, explained in the Aliases section
+  tenant_id:,
+  status:,
+  identifier:
+}
+```
+
+The `Togglefy.for_filters` will only apply the filters sent that are `nil` or `!value.blank?`.
 
 You can send `nil` values too, like:
 
@@ -212,12 +239,14 @@ Togglefy.with_status(:active)
 #### Finding a specific feature
 ```ruby
 Togglefy.feature(:super_powers)
+Togglefy::Feature.identifier(:super_powers)
 Togglefy::Feature.find_by(identifier: :super_powers)
 ```
 
 #### Finding a specific feature just to destroy it because you're mean 😈
 ```ruby
 Togglefy.destroy_feature(:super_powers)
+Togglefy::Feature.identifier(:super_powers).destroy
 Togglefy::Feature.find_by(identifier: :super_powers).destroy
 ```
 

--- a/app/models/togglefy/feature.rb
+++ b/app/models/togglefy/feature.rb
@@ -7,6 +7,8 @@ module Togglefy
 
     before_validation :build_identifier
 
+    scope :identifier, ->(identifier) { where(identifier:) }
+
     scope :for_group, ->(group) { where(group:) }
     scope :without_group, -> { where(group: nil) }
 

--- a/lib/togglefy/assignable.rb
+++ b/lib/togglefy/assignable.rb
@@ -1,0 +1,38 @@
+require "active_support/concern"
+
+module Togglefy
+  module Assignable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :feature_assignments, as: :assignable, class_name: "Togglefy::FeatureAssignment"
+      has_many :features, through: :feature_assignments, class_name: "Togglefy::Feature"
+    end
+
+    def has_feature?(identifier)
+      features.exists?(identifier: identifier.to_s)
+    end
+
+    def add_feature(feature)
+      feature = find_feature!(feature)
+      features << feature unless has_feature?(feature.identifier)
+    end
+
+    def remove_feature(feature)
+      feature = find_feature!(feature)
+      features.destroy(feature) if has_feature?(feature.identifier)
+    end
+
+    def clear_features
+      features.destroy_all
+    end
+
+    private
+
+    def find_feature!(feature)
+      return feature if feature.is_a?(Togglefy::Feature)
+
+      Togglefy::Feature.find_by!(identifier: feature.to_s)
+    end
+  end
+end

--- a/lib/togglefy/feature_manager.rb
+++ b/lib/togglefy/feature_manager.rb
@@ -14,12 +14,8 @@ module Togglefy
       self
     end
 
-    def clear(name = nil)
-      if name
-        assignable.remove_feature(name)
-      else
-        assignable.clear_features
-      end
+    def clear
+      assignable.clear_features
       self
     end
 

--- a/lib/togglefy/feature_manager.rb
+++ b/lib/togglefy/feature_manager.rb
@@ -6,14 +6,21 @@ module Togglefy
 
     def enable(feature)
       assignable.add_feature(feature)
+      self
     end
 
     def disable(feature)
       assignable.remove_feature(feature)
+      self
     end
 
-    def clear
-      assignable.clear_features
+    def clear(name = nil)
+      if name
+        assignable.remove_feature(name)
+      else
+        assignable.clear_features
+      end
+      self
     end
 
     def has?(feature)

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -47,16 +47,20 @@ module Togglefy
 
     def for_filters(filters)
       Togglefy::Feature
-        .then { |q| safe_chain(q, :for_group, filters[:group] || filters[:role]) }
-        .then { |q| safe_chain(q, :for_environment, filters[:environment] || filters[:env]) }
-        .then { |q| safe_chain(q, :for_tenant, filters[:tenant_id]) }
-        .then { |q| safe_chain(q, :with_status, filters[:status]) }
+        .then { |q| safe_chain(q, :for_group, filters[:group] || filters[:role], apply_if: filters.key?(:group) || filters.key?(:role)) }
+        .then { |q| safe_chain(q, :for_environment, filters[:environment] || filters[:env], apply_if: filters.key?(:environment) || filters.key?(:env)) }
+        .then { |q| safe_chain(q, :for_tenant, filters[:tenant_id], apply_if: filters.key?(:tenant_id)) }
+        .then { |q| safe_chain(q, :with_status, filters[:status], apply_if: filters.key?(:status)) }
     end
-
+    
     private
 
-    def safe_chain(query, method, value)
-      value ? query.public_send(method, value) : query
+    def safe_chain(query, method, value, apply_if: true)
+      apply_if && nil_or_not_blank?(value) ? query.public_send(method, value) : query
+    end
+
+    def nil_or_not_blank?(value)
+      value.nil? || !value.blank?
     end
   end
 end

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -41,15 +41,22 @@ module Togglefy
       Togglefy::Feature.without_tenant
     end
 
-    def for_filters(filters)
-      Togglefy::Feature
-        .for_group(filters[:group] || filters[:role])
-        .for_environment(filters[:environment] || filters[:env])
-        .for_tenant(filters[:tenant_id])
-    end
-
     def with_status(status)
       Togglefy::Feature.with_status(status)
+    end
+
+    def for_filters(filters)
+      Togglefy::Feature
+        .then { |q| safe_chain(q, :for_group, filters[:group] || filters[:role]) }
+        .then { |q| safe_chain(q, :for_environment, filters[:environment] || filters[:env]) }
+        .then { |q| safe_chain(q, :for_tenant, filters[:tenant_id]) }
+        .then { |q| safe_chain(q, :with_status, filters[:status]) }
+    end
+
+    private
+
+    def safe_chain(query, method, value)
+      value ? query.public_send(method, value) : query
     end
   end
 end

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -47,6 +47,7 @@ module Togglefy
 
     def for_filters(filters)
       Togglefy::Feature
+        .then { |q| safe_chain(q, :identifier, filters[:identifier], apply_if: filters.key?(:identifier)) }
         .then { |q| safe_chain(q, :for_group, filters[:group] || filters[:role], apply_if: filters.key?(:group) || filters.key?(:role)) }
         .then { |q| safe_chain(q, :for_environment, filters[:environment] || filters[:env], apply_if: filters.key?(:environment) || filters.key?(:env)) }
         .then { |q| safe_chain(q, :for_tenant, filters[:tenant_id], apply_if: filters.key?(:tenant_id)) }

--- a/lib/togglefy/featureable.rb
+++ b/lib/togglefy/featureable.rb
@@ -1,36 +1,6 @@
+require "togglefy/assignable"
+
 module Togglefy
-  module Featureable
-    extend ActiveSupport::Concern
-
-    included do
-      has_many :feature_assignments, as: :assignable, class_name: "Togglefy::FeatureAssignment"
-      has_many :features, through: :feature_assignments, class_name: "Togglefy::Feature"
-    end
-
-    def has_feature?(identifier)
-      features.exists?(identifier: identifier.to_s)
-    end
-
-    def add_feature(feature)
-      feature = find_feature!(feature)
-      features << feature unless has_feature?(feature.identifier)
-    end
-
-    def remove_feature(feature)
-      feature = find_feature!(feature)
-      features.destroy(feature) if has_feature?(feature.identifier)
-    end
-
-    def clear_features
-      features.destroy_all
-    end
-
-    private
-
-    def find_feature!(feature)
-      return feature if feature.is_a?(Togglefy::Feature)
-
-      Togglefy::Feature.find_by!(identifier: feature.to_s)
-    end
-  end
+  Featureable = Assignable
+  warn "[DEPRECATION] `Togglefy::Featureable` is deprecated. Use `Togglefy::Assignable` instead."
 end

--- a/togglefy.gemspec
+++ b/togglefy.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ["gazeveco@gmail.com"]
 
   spec.summary = "Simple and open source Feature Management."
-  spec.description = "Togglefy is a feature management solution to help you control which features an user or a group has access to."
+  spec.description = "Togglefy is a feature management Rails gem to help you control which features an user or a group has access to."
   spec.homepage = "https://github.com/azeveco/Togglefy"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.4.0"
@@ -31,10 +31,4 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end


### PR DESCRIPTION
# Context
To make Togglefy more dynamic, we need to add chaining to `FeatureManager`.

Also, the `for_filters` from `FeatureQuery` was applying all scopes, even if none was sent, causing a weird behaviour.

A rename of the `Featureable` was also required to make it more semantic.

# Resolution
## Chaining in `FeatureManager`
To add chaining to `FeatureManager`, the only thing needed was returning `self` at the end to each method.

Now you can chain methods from the `FeatureManager`.

Before, if you needed to disable a feature and then enable another one of an assignable, you have to do this:

```ruby
Togglefy.for(assignable).disable(:alpha_access)
Togglefy.for(assignable).enable(:beta_access)
```

Now you can superchage it and avoid code repetition by doing like this:

```ruby
Togglefy.for(assignable).disable(:alpha_access).enable(:beta_access)
```

## Improvements on `FeatureQuery.for_filters`
There was a problem with `for_filters` that were causing a misbehaviour.

If I wanted to list all features that from a specific group and environment, the resulting query was:

```sql
SELECT "togglefy_features".* FROM "togglefy_features" WHERE "togglefy_features"."group" = 'customer' AND "togglefy_features"."environment" = 'production' AND "togglefy_features"."tenant_id" IS NULL
```

As you can see, the `tenant_id` was still being applied as null, excluding from the results of the query valid records that did have a `tenant_id` and the other filters applied.

Now, the usage is still the same, but the resulting query is:

```sql
SELECT "togglefy_features".* FROM "togglefy_features" WHERE "togglefy_features"."group" = 'customer' AND "togglefy_features"."environment" = 'production'
```

And you can still send `nil` value. If a filter key is present, no matter if it's a `nil` or not, it will apply the scope. The difference is that if you don't send a filter, it won't do the scope query.

This PR also adds the `status` and `identifier` filters to the `for_filters` method. You can use it the same way:

```ruby
Togglefy.for_filters(filters: {group: :admin, status: :active, identifier: :super_powers})
```

# Impacted processes/locations
Make sure you write here which processes or locations were impacted by this PR.

Example:
* `FeatureQuery/for_type`: impacted because it changed its behaviour
* `create_features` migration: added a new column
* `install`: changed the behaviour of the `rails generate togglefy:install` command thanks to something

# References
You can link issues and articles on the context, resolution and more to strengthen the reason for your decisions, but this is a dedicated area just for that.