### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report 🪲
+about: Use this template to report a bug.
+labels: ["bug"]
+---
+
+# Context/current behaviour
+Describe the context of the bug. Try to include as many information as you can.
+
+# Expected behaviour
+Describe the expected behaviour and try to sustain why the expected behaviour you're describing is the correct.
+
+# Steps to reproduce
+Describe here the steps to reproduce this bug
+
+1. Do this
+2. Add the code
+3. Run the command
+4. Boom! 💣
+
+# Versions
+* **Gem version:** 1.0.2
+* **Rails version:** 8.0.2
+* **Ruby version:** 3.4.2
+* **OS and version (if aplicable):** macOS Sierra 10.12.6
+* **Brower(s) tested and versions (if aplicable):** Chrome 135.0.7049.85, Safari 18.3
+
+# Error logs
+Attach here error logs.
+
+Make sure you add them inside code blocks if you're thinking about placing the entire error here.
+
+# References
+Link here other issues, pull requests, key files, etc.

--- a/.github/ISSUE_TEMPLATE/02_new_feature.md
+++ b/.github/ISSUE_TEMPLATE/02_new_feature.md
@@ -1,0 +1,26 @@
+---
+name: New Feature 🚀
+about: Use this template to track a new feature that's already described inside the board/project.
+labels: ["enhancement"]
+---
+
+# Context
+Describe the context of the feature you're developing.
+
+# Steps
+Describe here the steps/subtasks to complete this issue.
+
+- [ ] 1st step
+- [ ] 2nd step
+- [ ] 3rd step
+- [ ] ...
+
+# Expected impact
+Describe here the expected impact using topics or just plain text and code blocks.
+
+Example:
+* `FeatureQuery/for_type`: expected to start returning the correct values
+* `rails generate togglefy:install`: expect to start doing this thing
+
+# References
+Link here other issues, articles, pull requests, key files, etc.

--- a/.github/ISSUE_TEMPLATE/03_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/03_feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request 💡
+about: Use this template request a feature.
+labels: ["request"]
+---
+
+# Context
+Describe the context of the feature you're requesting.
+
+# Logic/function/behaviour
+Describe here the behaviour/logic/function behind the feature you're requesting.
+
+Make sure you include as many examples as possible.
+
+# References
+Link here other issues, articles, pull requests, key files, design files, diagrams, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Togglefy Community Support
+    url: https://github.com/azeveco/Togglefy/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
# Context
We don't have issue templates. We need issue templates.

Issue templates are good.

So this PR aims to create what? Can you guess?

Issue templates.

# Resolution
Created issue templates inside issue templates directory.

Issue templates are awesome.

So this PR adds the issue templates.

Pretty good. I like it.

# Impacted processes/locations
* Impactes the process of creating issues, because now we have issue templates and issue templates are awesome.

# References
Issue templates are the reference for itself.