### PR TITLE
FeatureManager and FeatureAssignableManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ Togglefy.update_feature(:super_powers, tenant_id: "abc123")
 Or by finding the feature manually and then updating it like you always do with Rails:
 
 ```ruby
-feature = Togglefy::Feature.find_by(identifier: :super_powers) # You can do this by using another method specified at the "Finding a specific feature" section
+feature = Togglefy::Feature.find_by(identifier: :super_powers)
+# or
+feature = Togglefy.feature(:super_powers) # This is explained more in the "Finding a specific feature" section of this README
 
 feature.update(tenant_id: "123abc")
 ```
@@ -187,8 +189,15 @@ You can change the status by:
 * Updating the column
 * Doing a:
   ```ruby
-  Togglefy::Feature.active! # To activate
-  feature.inactive! # To inactivate
+  Togglefy::Feature.find_by(identifier: :super_powers).active!
+  Togglefy.feature(:super_powers).active!
+  Togglefy.active!(:super_powers)
+  Togglefy.activate_feature(:super_powers)
+
+  Togglefy::Feature.find_by(identifier: :super_powers).inactive!
+  Togglefy.feature(:super_powers).inactive!
+  Togglefy.inactive!(:super_powers)
+  Togglefy.inactivate_feature(:super_powers)
   ```
 
 ### Managing Assignables <-> Features
@@ -305,6 +314,12 @@ Togglefy.with_status(:active)
 Togglefy.feature(:super_powers)
 Togglefy::Feature.identifier(:super_powers)
 Togglefy::Feature.find_by(identifier: :super_powers)
+```
+
+#### Querying all features
+```ruby
+Togglefy.features(:super_powers)
+Togglefy::Feature.all
 ```
 
 #### Querying all features enabled to a klass

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Togglefy is free, open source and you are welcome to help build it.
 Add the gem manually to your Gemfile:
 
 ```gemfile
-gem 'togglefy', '~> 1.0', '>= 1.0.2'
+gem 'togglefy', '~> 1.0', '>= 1.1.0'
 ```
 
 Or install it and add to the application's Gemfile by executing:
@@ -67,7 +67,9 @@ Old versions (`<= 1.0.2`) had the `Featureable` instead of the `Assignable`. The
 
 With that, everything is ready to use **Togglefy**, welcome!
 
-### Creating Features
+### Managing Features
+
+#### Creating Features
 To create features it's as simple as drinking a nice cold beer after a hard day or drinking the entire bottle of coffee in a span of 1 hour:
 
 ```ruby
@@ -89,6 +91,24 @@ Togglefy::Feature.create(
 )
 ```
 
+You can also use:
+
+```ruby
+Togglefy.create(
+  name: "Teleportation",
+  description: "Allows the assignable to teleport to anywhere",
+  group: :jumper
+)
+
+# Or
+
+Togglefy.create_feature(
+  name: "Teleportation",
+  description: "Allows the assignable to teleport to anywhere",
+  group: :jumper
+)
+```
+
 You don't have to fill all fields, the only one that is mandatory is the name, because is by using the name that we will create the unique identifier, which is the field we'll use to find, delete and more.
 
 The identifier is the name, downcased and snake_cased 🐍
@@ -102,10 +122,51 @@ identifier: "super_powers",
 description: "With great power comes great responsibility",
 created_at: "2025-04-12 01:39:10.176561000 +0000",
 updated_at: "2025-04-12 01:39:46.818928000 +0000",
-tenant: "123abc",
+tenant_id: "123abc",
 group: "admin",
 environment: "production",
 status: "inactive"
+```
+
+#### Updating a Feature
+
+To update a feature is as simple as riding on a monocycle while balancing a cup of water on the top of a really tall person that's on your shoulders.
+
+Here's how you can do it:
+
+```ruby
+Togglefy.update(:super_powers, tenant_id: "abc123")
+Togglefy.update_feature(:super_powers, tenant_id: "abc123")
+```
+
+Or by finding the feature manually and then updating it like you always do with Rails:
+
+```ruby
+feature = Togglefy::Feature.find_by(identifier: :super_powers) # You can do this by using another method specified at the "Finding a specific feature" section
+
+feature.update(tenant_id: "123abc")
+```
+
+#### Destroying Features
+
+It looks like you're mean 😈
+
+So here's how you can destroy a feature:
+
+```ruby
+Togglefy.destroy(:super_powers)
+Togglefy.destroy_feature(:super_powers)
+Togglefy::Feature.identifier(:super_powers).destroy
+Togglefy::Feature.find_by(identifier: :super_powers).destroy
+```
+
+#### Toggle Features
+
+You can toggle a feature status to active or inactive by doing this:
+
+```ruby
+Togglefy.toggle(:super_powers)
+Togglefy.toggle_feature(:super_powers)
 ```
 
 #### About `Togglefy::Feature` status
@@ -126,7 +187,7 @@ You can change the status by:
 * Updating the column
 * Doing a:
   ```ruby
-  feature.active! # To activate
+  Togglefy::Feature.active! # To activate
   feature.inactive! # To inactivate
   ```
 
@@ -144,7 +205,7 @@ user.clear_features # Clears all features from an user
 
 The assignable <-> feature relation is held by the `Togglefy::FeatureAssignment` table/model.
 
-But there's another way to manage assignables <-> features by using the `FeatureManager`. It's up to you to decide which one.
+But there's another way to manage assignables <-> features by using the `FeatureAssignableManager`. It's up to you to decide which one.
 
 Here are the examples:
 
@@ -244,13 +305,6 @@ Togglefy.with_status(:active)
 Togglefy.feature(:super_powers)
 Togglefy::Feature.identifier(:super_powers)
 Togglefy::Feature.find_by(identifier: :super_powers)
-```
-
-#### Finding a specific feature just to destroy it because you're mean 😈
-```ruby
-Togglefy.destroy_feature(:super_powers)
-Togglefy::Feature.identifier(:super_powers).destroy
-Togglefy::Feature.find_by(identifier: :super_powers).destroy
 ```
 
 #### Querying all features enabled to a klass

--- a/README.md
+++ b/README.md
@@ -351,6 +351,26 @@ Togglefy.for_filters(filters: {environment: :production})
 Togglefy.for_filters(filter: {env: :production})
 ```
 
+## Aliases table
+
+Here's a table of all aliases available on Togglefy.
+
+You can use either, as long as you respect the rules listed.
+
+| Original              | Alias                | Rules                                               |
+| --------------------- | -------------------- | --------------------------------------------------- |
+| `for_group`           | `for_role`           | Can't be used if doing a direct `Togglefy::Feature` |
+| `without_group`       | `without_role`       | Can't be used if doing a direct `Togglefy::Feature` |
+| `for_environment`     | `for_env`            | Can't be used if doing a direct `Togglefy::Feature` |
+| `without_environment` | `without_env`        | Can't be used if doing a direct `Togglefy::Feature` |
+| `create`              | `create_feature`     | None                                                |
+| `update`              | `update_feature`     | None                                                |
+| `toggle`              | `toggle_feature`     | None                                                |
+| `active!`             | `activate_feature`   | None                                                |
+| `deactive!`           | `inactivate_feature` | None                                                |
+| `destroy`             | `destroy_feature`    | None                                                |
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/togglefy.rb
+++ b/lib/togglefy.rb
@@ -3,22 +3,21 @@
 require "togglefy/version"
 require "togglefy/engine"
 require "togglefy/featureable"
+require "togglefy/assignable"
+require "togglefy/feature_assignable_manager"
 require "togglefy/feature_manager"
 require "togglefy/feature_query"
 
 module Togglefy
   class Error < StandardError; end
 
+  # FeatureQuery
   def self.feature(identifier)
     FeatureQuery.new.feature(identifier)
   end
 
-  def self.destroy_feature(identifier)
-    FeatureQuery.new.destroy_feature(identifier)
-  end
-  
-  def self.for(assignable)
-    FeatureManager.new(assignable)
+  def self.features
+    FeatureQuery.new.features
   end
   
   def self.for_type(klass)
@@ -57,11 +56,50 @@ module Togglefy
     FeatureQuery.new.with_status(status)
   end
 
+  # FeatureManager
+  def self.create(**params)
+    FeatureManager.new.create(**params)
+  end
+
+  def self.update(identifier, **params)
+    FeatureManager.new(identifier).update(**params)
+  end
+
+  def self.destroy(identifier)
+    FeatureManager.new(identifier).destroy
+  end
+
+  def self.toggle(identifier)
+    FeatureManager.new(identifier).toggle
+  end
+
+  def self.active!(identifier)
+    FeatureManager.new(identifier).active!
+  end
+
+  def self.inactive!(identifier)
+    FeatureManager.new(identifier).inactive!
+  end
+
+  # FeatureAssignableManager
+  def self.for(assignable)
+    FeatureAssignableManager.new(assignable)
+  end
+
   class <<self
+    # FeatureQuery
     alias_method :for_role, :for_group
     alias_method :without_role, :without_group
 
     alias_method :for_env, :for_environment
     alias_method :without_env, :without_environment
+
+    # FeatureManager
+    alias_method :create_feature, :create
+    alias_method :update_feature, :update
+    alias_method :toggle_feature, :toggle
+    alias_method :activate_feature, :active!
+    alias_method :inactivate_feature, :inactive!
+    alias_method :destroy_feature, :destroy
   end
 end

--- a/lib/togglefy/feature_assignable_manager.rb
+++ b/lib/togglefy/feature_assignable_manager.rb
@@ -1,0 +1,30 @@
+module Togglefy
+  class FeatureAssignableManager
+    def initialize(assignable)
+      @assignable = assignable
+    end
+
+    def enable(feature)
+      assignable.add_feature(feature)
+      self
+    end
+
+    def disable(feature)
+      assignable.remove_feature(feature)
+      self
+    end
+
+    def clear
+      assignable.clear_features
+      self
+    end
+
+    def has?(feature)
+      assignable.has_feature?(feature)
+    end
+
+    private
+
+    attr_reader :assignable
+  end
+end

--- a/lib/togglefy/feature_manager.rb
+++ b/lib/togglefy/feature_manager.rb
@@ -1,30 +1,39 @@
 module Togglefy
   class FeatureManager
-    def initialize(assignable)
-      @assignable = assignable
+    def initialize(identifier = nil)
+      @identifier = identifier unless identifier.nil?
     end
 
-    def enable(feature)
-      assignable.add_feature(feature)
-      self
+    def create(**params)
+      Togglefy::Feature.create!(**params)
     end
 
-    def disable(feature)
-      assignable.remove_feature(feature)
-      self
+    def update(**params)
+      feature.update!(**params)
     end
 
-    def clear
-      assignable.clear_features
-      self
+    def destroy
+      feature.destroy
     end
 
-    def has?(feature)
-      assignable.has_feature?(feature)
+    def toggle
+      return feature.inactive! if feature.active?
+
+      feature.active!
+    end
+
+    def active!
+      feature.active!
+    end
+
+    def inactive!
+      feature.inactive!
     end
 
     private
 
-    attr_reader :assignable
+    def feature
+      Togglefy::Feature.find_by!(identifier: @identifier)
+    end
   end
 end

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -4,9 +4,8 @@ module Togglefy
       Togglefy::Feature.find_by!(identifier:)
     end
 
-    def destroy_feature(identifier)
-      feature = Togglefy::Feature.find_by!(identifier:)
-      feature&.destroy
+    def features
+      Togglefy::Feature.all
     end
 
     def for_type(klass)

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -15,22 +15,18 @@ module Togglefy
     def for_group(group)
       Togglefy::Feature.for_group(group)
     end
-    alias :for_role :for_group
 
     def without_group
       Togglefy::Feature.without_group
     end
-    alias :without_role :without_group
 
     def for_environment(environment)
       Togglefy::Feature.for_environment(environment)
     end
-    alias :for_env :for_environment
 
     def without_environment
       Togglefy::Feature.without_environment
     end
-    alias :without_env :without_environment
 
     def for_tenant(tenant_id)
       Togglefy::Feature.for_tenant(tenant_id)


### PR DESCRIPTION
# Context
Today, the `FeatureManager` manages the features to an assignable.

It works good, but semantically, it's better to rename it to `FeatureAssignableManager` because everything that's there is related to the assignable.

Then, we can repurpose the `FeatureManager` to actually manage features: create, update, delete, deactivate, activate and more.

# Resolution
* Renamed all occurences and files of `FeatureManager || feature_manager` to `FeatureAssignableManager || feature_assignable_manager`
* Created a new `FeatureManager`
* Moved the `destroy_feature` method from `FeatureQuery` to `FeatureManager`
* Created all other methods to actually manage features, like:
  * `create`
  * `update`
  * `toggle`
  * `active!`
  * `inactive!`

# Impacted processes/locations
* `FeatureManager`: the entire context of this has changed to the `FeatureAssignableManager`, but the latter was required and shouldn't impact anything.

Nothing else should be impacted as it is all new code.

# References
#25 