### PR TITLE
Mass Toggle by scopes and/or percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ include Togglefy::Assignable
 
 This will add the relationship between Togglefy's models and yours. Yours will be referred to as **assignable** throughout this documentation. If you want to check it in the source code, you can find it here: `lib/togglefy/assignable.rb` inside de `included` block.
 
-Old versions (`<= 1.0.2`) had the `Featureable` instead of the `Assignable`. The `Featureable` is now deprecated. You can still use it and it won't impact old users, but we highly recommend you to use the `Assignable` as it is semantically more accurate about what it does.
+Older versions (`<= 1.0.2`) had the `Featureable` instead of the `Assignable`. The `Featureable` is now deprecated. You can still use it and it won't impact old users, but we highly recommend you to use the `Assignable` as it is semantically more accurate about what it does.
 
 With that, everything is ready to use **Togglefy**, welcome!
 

--- a/app/models/togglefy/feature.rb
+++ b/app/models/togglefy/feature.rb
@@ -7,7 +7,10 @@ module Togglefy
 
     before_validation :build_identifier
 
-    scope :identifier, ->(identifier) { where(identifier:) }
+    scope :identifier, ->(identifier) {
+      identifiers = Array(identifier)
+      where(identifier: identifiers) 
+    }
 
     scope :for_group, ->(group) { where(group:) }
     scope :without_group, -> { where(group: nil) }

--- a/app/models/togglefy/feature.rb
+++ b/app/models/togglefy/feature.rb
@@ -7,10 +7,7 @@ module Togglefy
 
     before_validation :build_identifier
 
-    scope :identifier, ->(identifier) {
-      identifiers = Array(identifier)
-      where(identifier: identifiers) 
-    }
+    scope :identifier, ->(identifier) { where(identifier:) }
 
     scope :for_group, ->(group) { where(group:) }
     scope :without_group, -> { where(group: nil) }

--- a/lib/togglefy.rb
+++ b/lib/togglefy.rb
@@ -7,6 +7,7 @@ require "togglefy/assignable"
 require "togglefy/feature_assignable_manager"
 require "togglefy/feature_manager"
 require "togglefy/feature_query"
+require "togglefy/scoped_bulk_wrapper"
 
 module Togglefy
   class Error < StandardError; end
@@ -84,6 +85,10 @@ module Togglefy
   # FeatureAssignableManager
   def self.for(assignable)
     FeatureAssignableManager.new(assignable)
+  end
+
+  def self.for_type(klass)
+    Togglefy::ScopedBulkWrapper.new(klass)
   end
 
   class <<self

--- a/lib/togglefy.rb
+++ b/lib/togglefy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "togglefy/version"
-require "togglefy/engine"
+require "togglefy/engine" if defined?(Rails)
 require "togglefy/featureable"
 require "togglefy/assignable"
 require "togglefy/feature_assignable_manager"

--- a/lib/togglefy.rb
+++ b/lib/togglefy.rb
@@ -8,6 +8,7 @@ require "togglefy/feature_assignable_manager"
 require "togglefy/feature_manager"
 require "togglefy/feature_query"
 require "togglefy/scoped_bulk_wrapper"
+require "togglefy/exceptions"
 
 module Togglefy
   class Error < StandardError; end
@@ -87,6 +88,7 @@ module Togglefy
     FeatureAssignableManager.new(assignable)
   end
 
+  # ScopedBulkWrapper
   def self.mass_for(klass)
     Togglefy::ScopedBulkWrapper.new(klass)
   end

--- a/lib/togglefy.rb
+++ b/lib/togglefy.rb
@@ -13,12 +13,12 @@ module Togglefy
   class Error < StandardError; end
 
   # FeatureQuery
-  def self.feature(identifier)
-    FeatureQuery.new.feature(identifier)
-  end
-
   def self.features
     FeatureQuery.new.features
+  end
+
+  def self.feature(identifier)
+    FeatureQuery.new.feature(identifier)
   end
   
   def self.for_type(klass)
@@ -87,7 +87,7 @@ module Togglefy
     FeatureAssignableManager.new(assignable)
   end
 
-  def self.for_type(klass)
+  def self.mass_for(klass)
     Togglefy::ScopedBulkWrapper.new(klass)
   end
 

--- a/lib/togglefy/assignable.rb
+++ b/lib/togglefy/assignable.rb
@@ -8,7 +8,7 @@ module Togglefy
       has_many :feature_assignments, as: :assignable, class_name: "Togglefy::FeatureAssignment"
       has_many :features, through: :feature_assignments, class_name: "Togglefy::Feature"
 
-      scope :with_features, ->(feature_ids, filters = {}) {
+      scope :with_features, ->(feature_ids) {
         joins(:feature_assignments)
         .where(feature_assignments: {
           feature_id: feature_ids
@@ -16,7 +16,7 @@ module Togglefy
         .distinct
       }
 
-      scope :without_features, ->(feature_ids, filters = {}) {
+      scope :without_features, ->(feature_ids) {
         joins(left_join_on_features(feature_ids))
           .where("fa.id IS NULL")
           .distinct

--- a/lib/togglefy/assignable.rb
+++ b/lib/togglefy/assignable.rb
@@ -4,8 +4,6 @@ module Togglefy
   module Assignable
     extend ActiveSupport::Concern
 
-    ALLOWED_ASSIGNABLE_FILTERS = %i[group role environment env tenant_id].freeze
-
     included do
       has_many :feature_assignments, as: :assignable, class_name: "Togglefy::FeatureAssignment"
       has_many :features, through: :feature_assignments, class_name: "Togglefy::Feature"
@@ -62,10 +60,6 @@ module Togglefy
             AND fa.assignable_type = '#{type}'
             AND fa.feature_id IN (#{Array(feature_ids).join(",")})
         SQL
-      end
-
-      def scoped_filters(filters)
-        where(filters.slice(ALLOWED_ASSIGNABLE_FILTERS).compact)
       end
     end
   end

--- a/lib/togglefy/errors/assignables_not_found.rb
+++ b/lib/togglefy/errors/assignables_not_found.rb
@@ -1,0 +1,7 @@
+module Togglefy
+  class AssignablesNotFound < Togglefy::Error
+    def initialize(klass)
+      super("No #{klass.name} found matching features and filters sent")
+    end
+  end
+end

--- a/lib/togglefy/errors/bulk_toggle_failed.rb
+++ b/lib/togglefy/errors/bulk_toggle_failed.rb
@@ -1,0 +1,11 @@
+module Togglefy
+  class BulkToggleFailed < Togglefy::Error
+    def initialize(message = "Bulk toggle operation failed", cause = nil)
+      super(message)
+      set_backtrace(cause.backtrace) if cause
+      @cause = cause
+    end
+
+    attr_reader :cause
+  end
+end

--- a/lib/togglefy/errors/dependency_missing.rb
+++ b/lib/togglefy/errors/dependency_missing.rb
@@ -1,0 +1,7 @@
+module Togglefy
+  class DependencyMissing < Togglefy::Error
+    def initialize(feature, required)
+      super("Feature '#{feature}' is missing dependency: '#{required}'")
+    end
+  end
+end

--- a/lib/togglefy/errors/error.rb
+++ b/lib/togglefy/errors/error.rb
@@ -1,0 +1,3 @@
+module Togglefy
+  class Error < StandardError; end
+end

--- a/lib/togglefy/errors/feature_not_found.rb
+++ b/lib/togglefy/errors/feature_not_found.rb
@@ -1,0 +1,7 @@
+module Togglefy
+  class FeatureNotFound < Togglefy::Error
+    def initialize
+      super("No features found matching features and/or filters sent")
+    end
+  end
+end

--- a/lib/togglefy/errors/invalid_feature_attribute.rb
+++ b/lib/togglefy/errors/invalid_feature_attribute.rb
@@ -1,0 +1,7 @@
+module Togglefy
+  class InvalidFeatureAttribute < Togglefy::Error
+    def initialize(attr)
+      super("The attribute '#{attr}' is not valid for Togglefy::Feature.")
+    end
+  end
+end

--- a/lib/togglefy/exceptions.rb
+++ b/lib/togglefy/exceptions.rb
@@ -1,0 +1,5 @@
+require "togglefy/errors/error"
+
+require "togglefy/errors/feature_not_found"
+require "togglefy/errors/assignables_not_found"
+require "togglefy/errors/bulk_toggle_failed"

--- a/lib/togglefy/feature_manager.rb
+++ b/lib/togglefy/feature_manager.rb
@@ -32,8 +32,10 @@ module Togglefy
 
     private
 
+    attr_reader :identifier
+
     def feature
-      Togglefy::Feature.find_by!(identifier: @identifier)
+      Togglefy::Feature.find_by!(identifier:)
     end
   end
 end

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -1,6 +1,8 @@
 module Togglefy
   class FeatureQuery
     def feature(identifier)
+      return Togglefy::Feature.identifier(identifier) if identifier.is_a? Array
+
       Togglefy::Feature.find_by!(identifier:)
     end
 

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -1,13 +1,13 @@
 module Togglefy
   class FeatureQuery
+    def features
+      Togglefy::Feature.all
+    end
+
     def feature(identifier)
       return Togglefy::Feature.identifier(identifier) if identifier.is_a? Array
 
       Togglefy::Feature.find_by!(identifier:)
-    end
-
-    def features
-      Togglefy::Feature.all
     end
 
     def for_type(klass)

--- a/lib/togglefy/feature_query.rb
+++ b/lib/togglefy/feature_query.rb
@@ -5,7 +5,7 @@ module Togglefy
     end
 
     def feature(identifier)
-      return Togglefy::Feature.identifier(identifier) if identifier.is_a? Array
+      return Togglefy::Feature.identifier(identifier) if identifier.is_a?(Array)
 
       Togglefy::Feature.find_by!(identifier:)
     end

--- a/lib/togglefy/scoped_bulk_wrapper.rb
+++ b/lib/togglefy/scoped_bulk_wrapper.rb
@@ -1,0 +1,13 @@
+require "togglefy/services/bulk_toggler"
+
+module Togglefy
+  class ScopedBulkWrapper
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def bulk
+      BulkToggler.new(@klass)
+    end
+  end
+end

--- a/lib/togglefy/services/bulk_toggler.rb
+++ b/lib/togglefy/services/bulk_toggler.rb
@@ -29,9 +29,9 @@ module Togglefy
       feature_ids = features.map(&:id)
 
       assignables = if action == :enable
-        klass.without_features(feature_ids, filters)
+        klass.without_features(feature_ids)
       else
-        klass.with_features(feature_ids, filters)
+        klass.with_features(feature_ids)
       end
 
       raise Togglefy::AssignablesNotFound.new(klass, identifiers, filters) if assignables.empty?

--- a/lib/togglefy/services/bulk_toggler.rb
+++ b/lib/togglefy/services/bulk_toggler.rb
@@ -20,26 +20,68 @@ module Togglefy
 
     def toggle(action, identifiers, filters)
       identifiers = Array(identifiers)
+      features = Togglefy.for_filters(filters: {identifier: identifiers}.merge(build_scope_filters(filters))).to_a # FIXME: For filters returning different features
+      feature_ids = features.map(&:id)
 
-      features = Togglefy.for_filters(filters: {identifier: identifiers}).to_a
-
-      assignables = klass.where(build_scope_filters(filters)) # TODO: Get only the ones that do/don't already have the feature
-
-      if filters[:percentage]
-        count = (assignables.size * filters[:percentage].to_f / 100).round
-        assignables = assignables.sample(count)
+      assignables = if action == :enable
+        klass.without_features(feature_ids, filters)
+      else
+        klass.with_features(feature_ids, filters)
       end
+      
+      assignables = sample_assignables(assignables, filters[:percentage]) if filters[:percentage]
 
-      assignables.each do |assignable|
-        manager = Togglefy.for(assignable)
-        features.each do |feature|
-          action == :enable ? manager.enable(feature.identifier) : manager.disable(feature.identifier)
+      existing_assignments = Togglefy::FeatureAssignment.where(
+        assignable_id: assignables.map(&:id),
+        assignable_type: klass.name,
+        feature_id: features.map(&:id)
+      ).pluck(:assignable_id, :feature_id)
+
+      existing_lookup = Set.new(existing_assignments)
+      
+      if action == :enable
+        rows = []
+
+        assignables.each do |assignable|
+          features.each do |feature|
+            key = [assignable.id, feature.id]
+            next if existing_lookup.include?(key)
+
+            rows << {
+              assignable_id: assignable.id,
+              assignable_type: assignable.class.name,
+              feature_id: feature.id
+            }
+          end
+        end
+
+        Togglefy::FeatureAssignment.insert_all(rows) if rows.any?
+      elsif action == :disable
+        ids_to_remove = []
+        assignables.each do |assignable|
+          features.each do |feature|
+            key = [assignable.id, feature.id]
+            ids_to_remove << key if existing_lookup.include?(key)
+          end
+        end
+
+        if ids_to_remove.any?
+          Togglefy::FeatureAssignment.where(
+            assignable_id: ids_to_remove.map(&:first),
+            assignable_type: klass.name,
+            feature_id: ids_to_remove.map(&:last)
+          ).delete_all
         end
       end
     end
 
     def build_scope_filters(filters)
       filters.slice(*ALLOWED_ASSIGNABLE_FILTERS).compact
+    end
+
+    def sample_assignables(assignables, percentage)
+      count = (assignables.size * percentage.to_f / 100).round
+      assignables.sample(count)
     end
   end
 end

--- a/lib/togglefy/services/bulk_toggler.rb
+++ b/lib/togglefy/services/bulk_toggler.rb
@@ -1,0 +1,45 @@
+module Togglefy
+  class BulkToggler
+    ALLOWED_ASSIGNABLE_FILTERS = %i[group role environment env tenant_id].freeze
+
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def enable(identifiers, **filters)
+      toggle(:enable, identifiers, filters)
+    end
+
+    def disable(identifiers, **filters)
+      toggle(:disable, identifiers, filters)
+    end
+
+    private
+
+    attr_reader :klass
+
+    def toggle(action, identifiers, filters)
+      identifiers = Array(identifiers)
+
+      features = Togglefy.for_filters(filters: {identifier: identifiers}).to_a
+
+      assignables = klass.where(build_scope_filters(filters)) # TODO: Get only the ones that do/don't already have the feature
+
+      if filters[:percentage]
+        count = (assignables.size * filters[:percentage].to_f / 100).round
+        assignables = assignables.sample(count)
+      end
+
+      assignables.each do |assignable|
+        manager = Togglefy.for(assignable)
+        features.each do |feature|
+          action == :enable ? manager.enable(feature.identifier) : manager.disable(feature.identifier)
+        end
+      end
+    end
+
+    def build_scope_filters(filters)
+      filters.slice(*ALLOWED_ASSIGNABLE_FILTERS).compact
+    end
+  end
+end


### PR DESCRIPTION
# Context
Enable/disable one or more features filtered by TEG (tenant, environment, group) across all assignables and/or by a percentage of assignables.

# Resolution
The main point of this PR was to add the mass toggle, but during the implementation of this, I felt the need to define exceptions to use.

So this PR has a nice bonus!

Let's start by the `ScopedBulkWrapper` which will hold all methods related to a mass/bulk action.

## Mass/bulk action
It is required inside the `lib/togglefy.rb`.

And it is defined here:
https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy.rb#L92-L94

Because the `ScopedBulkWrapper` will hold all mass/bulk methods, I decided to build the enable/disable mass action inside what I'm calling a service called `BulkToggler` as you can see below:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/scoped_bulk_wrapper.rb#L1-L13

This way, whenever we have a new type to mass/bulk action, we can create a new service and require/define it on the `ScopeBulkWrapper` to help us with readability and allowing files to keep as low lines as possible.

Now, as you can see, the `BulkToggler` service is what holds the methods to actually do a mass toggle. And it is our biggest file yet (if we disconsider the `togglefy.rb`).

Opening the `BulkToggler` service, you can see in the `initialize` that it requires a klass to be sent. This class is the assignable. Is you model called user? Send `User`. Is it called account? Send `Account`. And so on.

You can also see that this service contains two methods:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L9-L15

As you can see, both can receive `identifiers` (yes, plural) and `filters`.

To know which filters we currently accept, you can check at the constant on the top of the class:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L3

As you already now: group/role and environment/env are the same. Just different aliases.

These filters will only be applied to look for features.

So, let's get to the `toggle` method:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L21

I obviously can't link it here, but I'll link a few key parts.

Basically, we convert the identifiers to array, so the identifiers you can send can be like Han Solo:

```ruby
:super_powers
```

Or an array of identifiers:

```ruby
[:super_powers, :magic]
```

Then, we will search for features that match the identifiers + the filters we already discussed above. FYI: it's the same filters of the `.for_filters` except the status and identifiers.

If there's no features, we will raise an exception:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L27

After that, we need to get all assignables so we can mass enable/disable features. We do that here:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L31-L35

As you can see, if it's enable it uses the `without_features` and if t's disable it uses the `with_features`. These are scopes that were created and added to the `Assignable`, which is the concern you will need to include on the model you plan to use for features:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/assignable.rb#L11-L23

But you may be asking: why?

Well... because we don't want to do a mass enable to a sample of assignables that consists of assignables that don't have the feature and some that already do.

If you're doing a mass enable, you want only valid assignables to get the features.

The same applies to the disable: we get all the assignables that already have the features.

And what if we can find assignables? We raise an exception:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L37

All good so far? Okay, let's continue.

What if you want to apply this mass action to 20% of your assignables? Well, there's another filter you can send to help you with that!

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L39

By sending a filter `percentage`, you can specify if you want to apply this to only 10%, 20%, 5%, 75% of assignables. By the way, when you send it, make sure to don't include the % sign. Use an integer.

So, if there's a percentage filter, we will sample assignables to get only the percentage you want.

Next, we will do a few things to ensure that the assignables don't have the features. They shouldn't, but another check isn't the worst thing in the world.

Now we got to the part where we check if the action is enable or disable.

If it's enable, we will do some checks and add to a row the params to add a feature to an assignable. How do we do that?

Like this:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L57-L61

And then, after looping all features and assignables, we wil do a `.insert_all` with everything all at once. And if there's any error, we will rescue and raise a `Togglefy::BulkToggleFailed`:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/services/bulk_toggler.rb#L65-L72

We will do the exat same with the disable action, but we will do a `.delete_all`. We also rescue and raise the same Exception.

## Exceptions
Okay, I didn't plan this but the last section ended with Exception and the new starts with Exception.

Maybe it's destiny?

Okay, as you saw: we raise exceptions in many parts of this code. I felt the need to start doing that.

So, what I did was create a `lib/togglefy/exceptions.rb` to require all exceptions, the require this file inside the `lib/togglefy.rb` and store all the custom exceptions inside the `lib/togglefy/errors` path.

As you can see, there's more exceptions than the ones I already required inside the `exceptions.rb` file. This is because my brain was giving me ideas of exceptions, but I didn't have the time to implement them.

But it's basically that. You are welcome to raise these on other parts of the code and then require then inside the `exceptions.rb`. You are also welcome to change the existing ones and also you can create new exceptions!

## Another bonuses
Well... there's always things to do, am I right?

**First things first**:
I've changed the scope `identifier` of the `Togglefy::Feature` to allow arrays.

**Second things second**:
I've added a `if defined?(Rails)` next to the `require "togglefy/engine"`. We are almost ready to have tests, y'all!

**Third things third**:
I've changed the `feature` method of the `FeatureQuery` to include the use of array:

https://github.com/azeveco/Togglefy/blob/136276bb15c05b67a1f287d64cde0869d20e7346/lib/togglefy/feature_query.rb#L7-L11

Was all of this necessary? Probably not... we could onlt use the scope, no `.find_by`, etc.

# Impacted processes/locations
Actually it shouldn't impact anything that was already there

What will impact is the ability to release features to percentage of assignables or to all. This is great for feature releases!

# References
#20 