### PR TITLE
Fixes Rails migration versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,37 @@ After adding the gem to your project, you need to run the generate command to ad
 rails generate togglefy:install
 ```
 
-This command will create the migrations to create the tables inside your project. Please, don't remove/change anything that's there or Togglefy may not work as expected.
+This command will create the migrations to create the tables inside your project.
+
+If you use an older version of Rails (< 5), then the migration files don't need you to specify the version.
+
+To fix this, you will have to manually go to the two migration files of Togglefy: `create_feature` and `create_feature_assignments` and do the following:
+
+Change these lines from this:
+
+```ruby
+rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+
+class CreateTogglefyFeatures < ActiveRecord::Migration[rails_version]
+```
+
+```ruby
+rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+
+class CreateTogglefyFeatureAssignments < ActiveRecord::Migration[rails_version]
+```
+
+To this:
+
+```ruby
+class CreateTogglefyFeatures < ActiveRecord::Migration
+```
+
+```ruby
+class CreateTogglefyFeatureAssignments < ActiveRecord::Migration
+```
+
+Please, don't remove/change anything else that's there or Togglefy may not work as expected.
 
 Run the migration to create these in your datase:
 ```bash

--- a/lib/generators/togglefy/templates/create_feature_assignments.rb
+++ b/lib/generators/togglefy/templates/create_feature_assignments.rb
@@ -1,4 +1,8 @@
-class CreateTogglefyFeatureAssignments < ActiveRecord::Migration[8.0]
+# frozen_string_literal: true
+
+rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+
+class CreateTogglefyFeatureAssignments < ActiveRecord::Migration[rails_version]
   def change
     create_table :togglefy_feature_assignments do |t|
       t.references :feature, null: false, foreign_key: { to_table: :togglefy_features }

--- a/lib/generators/togglefy/templates/create_features.rb
+++ b/lib/generators/togglefy/templates/create_features.rb
@@ -1,4 +1,8 @@
-class CreateTogglefyFeatures < ActiveRecord::Migration[8.0]
+# frozen_string_literal: true
+
+rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+
+class CreateTogglefyFeatures < ActiveRecord::Migration[rails_version]
   def change
     create_table :togglefy_features do |t|
       t.string :name, null: false

--- a/lib/togglefy/version.rb
+++ b/lib/togglefy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Togglefy
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
# Context
The migration files were always applying the 8.0 version. This breaks if you install the gem on older Rails except if you manually enter the migration after the install command to change/remove the version.

# Resolution
Added the following on the top of each migration file:
```ruby
rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
```

Then, we use it here:
```ruby
ActiveRecord::Migration[rails_version]
```

If it's an older version that doesn't support version in migration files, you still need to change the migration file manually and just remove the following.

From this:
```ruby
rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"

class CreateTogglefyFeatures < ActiveRecord::Migration[rails_version]
```

```ruby
rails_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"

class CreateTogglefyFeatureAssignments < ActiveRecord::Migration[rails_version]
```

To this:
```ruby
class CreateTogglefyFeatures < ActiveRecord::Migration
```

```ruby
class CreateTogglefyFeatureAssignments < ActiveRecord::Migration
```

# Impacted processes/locations
Migration files for Togglefy.