### PR TITLE
fix: readme and getting started typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Make sure that the migration `CreateTogglefyFeatureAssignments` have the correct
 
 Please, don't remove/change anything else that's there or Togglefy may not work as expected.
 
-Run the migration to create these in your datase:
+Run the migration to create these in your database:
 
 ```bash
 rails db:migrate

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -65,7 +65,7 @@ Example: if you use `UUID`, check if it will automatically use it. If not, speci
 
 #### Running the migrations
 
-Run the migration to create these in your datase:
+Run the migration to create these in your database:
 ```bash frame="none"
 rails db:migrate
 ```


### PR DESCRIPTION
# Context
There's a small typo inside the README and the getting-started page from the the official documentation.

# Resolution
Fixed the typo.