### PR TITLE
[FEATURE] Analytics first version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Make sure that the migration `CreateTogglefyFeatureAssignments` have the correct
 
 Please, don't remove/change anything else that's there or Togglefy may not work as expected.
 
-Run the migration to create these in your datase:
+Run the migration to create these in your database:
 
 ```bash
 rails db:migrate

--- a/README.md
+++ b/README.md
@@ -431,7 +431,78 @@ You want to list all features being used by assignables of User type:
 Togglefy.for_type(User) # This returns all current FeatureAssignment with a User assignable
 ```
 
-#### Aliases
+## Analytics
+
+So, you’ve been flipping features on and off like a light switch at a disco — but now you’re wondering:
+
+> "How many people are actually using this shiny new feature I just toggled on?"
+
+Or maybe:
+
+> "Did I toggle something into oblivion and forget about it?"
+
+Fear not — the Analytics module is here to save your (data-driven) soul.
+
+#### Tracking a Feature usage data
+
+You can track usage data for a single feature in your system by providing its `Togglefy::Feature` identifier:
+
+```ruby
+Togglefy.analytics_for(:teleportation) # :teleportation is the Feature's identifier column
+```
+
+This will return an array of hashes, with each hash representing an Assignable in your system (e.g., User, Account, Group, etc.).
+
+Here’s what the result might look like:
+
+```ruby
+[
+    {
+        assignable: "User",
+        total: 50,
+        enabled_count: 20,
+        disabled_count: 30,
+        percentage_enabled: "40.0%",
+        percentage_disabled: "60.0%",
+        first_created: 2025-04-21 01:43:28.266664000 UTC +00:00,
+        last_created: 2025-05-21 19:18:37.772172000 UTC +00:00,
+        past_7: 9,
+        past_14: 11,
+        past_30: 0
+    },
+    {
+        assignable: "Account",
+        total: 4,
+        enabled_count: 2,
+        disabled_count: 0,
+        percentage_enabled: "100.0%",
+        percentage_disabled: "0.0%",
+        first_created: 2025-04-21 01:43:28.266664000 UTC +00:00,
+        last_created: 2025-05-21 19:18:37.772172000 UTC +00:00,
+        past7: 2,
+        past14: 0,
+        past30: 0
+    }
+]
+```
+
+So, how you should interpret that data?
+
+Here’s what each field means:
+
+- `assignable`: The model that includes Togglefy::Assignable.
+- `total`: Total number of assignables in your system.
+- `enabled_count`: Number of assignables that have the feature enabled.
+- `disabled_count`: Number of assignables that have the feature disabled.
+- `percentage_enabled`: Percentage of assignables with the feature enabled.
+- `percentage_disabled`: Percentage of assignables with the feature disabled.
+- `first_created`: The first time the feature was toggled on for this assignable.
+- `last_created`: The most recent time the feature was toggled on for this assignable.
+- `past_7`: Number of times the feature was toggled on in the past 7 days.
+- `past_14`: Number of times the feature was toggled on in the past 14 days.
+- `past_30`: Number of times the feature was toggled on in the past 30 days.
+
+## Aliases
 
 By the way, did you notice that I wrote `group` and `role` to get group?
 
@@ -452,7 +523,7 @@ Togglefy.for_filters(filters: {environment: :production})
 Togglefy.for_filters(filter: {env: :production})
 ```
 
-## Aliases table
+#### Aliases table
 
 Here's a table of all aliases available on Togglefy.
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -59,6 +59,7 @@ export default defineConfig({
                     { label: 'Managing Features', slug: 'usage/managing-features' },
                     { label: 'Managing Assignables <> Features', slug: 'usage/managing-assignables-features' },
                     { label: 'Querying Features', slug: 'usage/querying-features' },
+                    { label: 'Analytics', slug: 'usage/analytics' },
                     { label: 'Aliases', slug: 'usage/aliases' }
                   ]
                 },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
                     { label: 'Togglefy::FeatureManager', slug: 'reference/api/togglefy-feature-manager' },
                     { label: 'Togglefy::FeatureAssignableManager', slug: 'reference/api/togglefy-feature-assignable-manager' },
                     { label: 'Togglefy::ScopedBulkWrapper', slug: 'reference/api/togglefy-scoped-bulk-wrapper' },
+                    { label: 'Togglefy::Analytics', slug: 'reference/api/togglefy-analytics' }
                   ]
                 },
                 {

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -65,7 +65,7 @@ Example: if you use `UUID`, check if it will automatically use it. If not, speci
 
 #### Running the migrations
 
-Run the migration to create these in your datase:
+Run the migration to create these in your database:
 ```bash frame="none"
 rails db:migrate
 ```

--- a/docs/src/content/docs/reference/api/togglefy-analytics.mdx
+++ b/docs/src/content/docs/reference/api/togglefy-analytics.mdx
@@ -1,0 +1,44 @@
+---
+title: Togglefy::Analytics
+description: Analytics module, responsible for tracking usage information of your Features
+---
+
+This module provides analytics functionality for Togglefy. It analyzes feature usage and assignment data, given feature identifier on initialization.
+
+:::note
+For the methods here, you need to initialize the Analytics class before you can actually call the methods.
+:::
+
+## Methods
+
+#### track
+
+**Description**
+
+---
+
+Based on the `identifier` provided in the initialization, generates analytics data for the found Feature.
+
+**Usage**
+
+---
+
+```ruby
+Togglefy.analytics_for(:identifier_slug)
+```
+
+**Parameters**
+
+---
+
+```ruby
+identifier: Symbol || String # Required
+```
+
+**Return**
+
+---
+
+```ruby
+[Array<Hash>]
+```

--- a/docs/src/content/docs/reference/api/togglefy-analytics.mdx
+++ b/docs/src/content/docs/reference/api/togglefy-analytics.mdx
@@ -5,10 +5,6 @@ description: Analytics module, responsible for tracking usage information of you
 
 This module provides analytics functionality for Togglefy. It analyzes feature usage and assignment data, given feature identifier on initialization.
 
-:::note
-For the methods here, you need to initialize the Analytics class before you can actually call the methods.
-:::
-
 ## Methods
 
 #### track

--- a/docs/src/content/docs/reference/api/togglefy.mdx
+++ b/docs/src/content/docs/reference/api/togglefy.mdx
@@ -42,3 +42,4 @@ The provided APIs from `Togglefy` involves three classes:
 - [Togglefy::FeatureManager](../togglefy-feature-manager): to manage features (status, create, update, etc)
 - [Togglefy::FeatureAssignableManager](../togglefy-feature-assignable-manager): to manage the relation between feature and assignables
 - [Togglefy::ScopedBulkWrapper](../togglefy-scoped-bulk-wrapper): to trigger bulk/mass operations
+- [Togglefy::Analytics](../togglefy-analytics): to track features analysis data

--- a/docs/src/content/docs/usage/analytics.mdx
+++ b/docs/src/content/docs/usage/analytics.mdx
@@ -1,0 +1,73 @@
+---
+title: Analytics
+description: Learn how to track usage information from your Features
+---
+
+So, you’ve been flipping features on and off like a light switch at a disco — but now you’re wondering:
+
+> "How many people are actually using this shiny new feature I just toggled on?"
+
+Or maybe:
+
+> "Did I toggle something into oblivion and forget about it?"
+
+Fear not — the Analytics module is here to save your (data-driven) soul.
+
+## Tracking a Feature usage data
+
+You can track usage data for a single feature in your system by providing its `Togglefy::Feature` identifier:
+
+```ruby
+Togglefy.analytics_for(:teleportation) # :teleportation is the Feature's identifier column
+```
+
+This will return an array of hashes, with each hash representing an Assignable in your system (e.g., User, Account, Group, etc.).
+
+Here’s what the result might look like:
+
+```ruby
+[
+    {
+        assignable: "User",
+        total: 50,
+        enabled_count: 20,
+        disabled_count: 30,
+        percentage_enabled: "40.0%",
+        percentage_disabled: "60.0%",
+        first_created: 2025-04-21 01:43:28.266664000 UTC +00:00,
+        last_created: 2025-05-21 19:18:37.772172000 UTC +00:00,
+        past_7: 9,
+        past_14: 11,
+        past_30: 0
+    },
+    {
+        assignable: "Account",
+        total: 4,
+        enabled_count: 2,
+        disabled_count: 0,
+        percentage_enabled: "100.0%",
+        percentage_disabled: "0.0%",
+        first_created: 2025-04-21 01:43:28.266664000 UTC +00:00,
+        last_created: 2025-05-21 19:18:37.772172000 UTC +00:00,
+        past7: 2,
+        past14: 0,
+        past30: 0
+    }
+]
+```
+
+So, how you should interpret that data?
+
+Here’s what each field means:
+
+- `assignable`: The model that includes Togglefy::Assignable.
+- `total`: Total number of assignables in your system.
+- `enabled_count`: Number of assignables that have the feature enabled.
+- `disabled_count`: Number of assignables that have the feature disabled.
+- `percentage_enabled`: Percentage of assignables with the feature enabled.
+- `percentage_disabled`: Percentage of assignables with the feature disabled.
+- `first_created`: The first time the feature was toggled on for this assignable.
+- `last_created`: The most recent time the feature was toggled on for this assignable.
+- `past_7`: Number of times the feature was toggled on in the past 7 days.
+- `past_14`: Number of times the feature was toggled on in the past 14 days.
+- `past_30`: Number of times the feature was toggled on in the past 30 days.

--- a/lib/togglefy.rb
+++ b/lib/togglefy.rb
@@ -9,6 +9,7 @@ require "togglefy/feature_manager"
 require "togglefy/feature_query"
 require "togglefy/scoped_bulk_wrapper"
 require "togglefy/errors"
+require "togglefy/analytics"
 
 # The Togglefy module provides a feature management system.
 # It includes methods for querying, creating, updating, toggling, and managing features.
@@ -235,6 +236,13 @@ module Togglefy
   # @return [ScopedBulkWrapper] The bulk wrapper for the class.
   def self.mass_for(klass)
     Togglefy::ScopedBulkWrapper.new(klass)
+  end
+
+  # Provides analytics tracking for a specific feature.
+  # @param identifier [Symbol, String] The unique identifier of the feature.
+  # @return [Array] list of Hashes, each Hash representing an Assignable with its tracking data.
+  def self.analytics_for(identifier)
+    Togglefy::Analytics.new(identifier).track
   end
 
   class << self

--- a/lib/togglefy/analytics.rb
+++ b/lib/togglefy/analytics.rb
@@ -122,7 +122,7 @@ module Togglefy
       {
         enabled_count: enabled_count,
         disabled_count: disabled_count,
-        total_count: total,
+        total: total,
         percentage_enabled: calculate_percentage(enabled_count, total),
         percentage_disabled: calculate_percentage(disabled_count, total)
       }

--- a/lib/togglefy/analytics.rb
+++ b/lib/togglefy/analytics.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Togglefy
+  class Analytics
+    def initialize(identifier = nil)
+      @identifier = identifier
+      @feature = fetch_feature
+    end
+
+    def track
+      return [] unless @feature
+
+      build_tracking_data
+    end
+
+    private
+
+    def fetch_feature
+      Togglefy.feature(@identifier) || nil
+    end
+
+    def build_tracking_data
+      assignables.filter_map do |assignable|
+        assignable_class = safe_constantize(assignable)
+        next unless assignable_class
+
+        assignable_data = build_assignables_data(assignable_class)
+        assignments_data = build_assignments_data
+
+        {
+          assignable: assignable,
+          total: assignable_data[:total_count],
+          enabled_count: assignable_data[:enabled_count],
+          disabled_count: assignable_data[:disabled_count],
+          percentage_enabled: assignable_data[:percentage_enabled],
+          percentage_disabled: assignable_data[:percentage_disabled],
+          first_created: assignments_data[:first_created],
+          last_created: assignments_data[:last_created],
+          past7: assignments_data[:past7],
+          past14: assignments_data[:past14],
+          past30: assignments_data[:past30]
+        }
+      end
+    end
+
+    def assignables
+      @assignables ||= assignments.map(&:assignable_type).uniq
+    end
+
+    def assignments
+      @assignments ||= @feature ? Togglefy::FeatureAssignment.where(feature_id: @feature.id) : []
+    end
+
+    def safe_constantize(assignable)
+      assignable.constantize
+    rescue NameError => e
+      Rails.logger.warn("Invalid assignable class: #{assignable} - #{e.message}")
+      nil
+    end
+
+    def build_assignables_data(klass)
+      return default_assignable_data unless klass.respond_to?(:with_features) && klass.respond_to?(:without_features)
+
+      with_features = klass.with_features(@feature.id)
+      without_features = klass.without_features(@feature.id)
+
+      enabled_count = with_features.count
+      disabled_count = without_features.count
+      total_count = enabled_count + disabled_count
+
+      return default_assignable_data if total_count.zero?
+
+      {
+        enabled_count: enabled_count,
+        disabled_count: disabled_count,
+        total_count: total_count,
+        percentage_enabled: calculate_percentage(enabled_count, total_count),
+        percentage_disabled: calculate_percentage(disabled_count, total_count)
+      }
+    end
+
+    def default_assignable_data
+      {
+        enabled_count: 0,
+        disabled_count: 0,
+        total_count: 0,
+        percentage_enabled: "0.00%",
+        percentage_disabled: "0.00%"
+      }
+    end
+
+    def calculate_percentage(count, total)
+      return "0.00%" if total.zero?
+
+      percentage = (count.to_f / total.to_f * 100).round(2)
+      "#{percentage}%"
+    end
+
+    def build_assignments_data
+      return default_assignments_data if assignments.empty?
+
+      {
+        last_created: assignments.maximum(:created_at),
+        first_created: assignments.minimum(:created_at),
+        past7: count_assignments_in_period(7.days.ago),
+        past14: count_assignments_in_period(14.days.ago),
+        past30: count_assignments_in_period(30.days.ago)
+      }
+    end
+
+    def count_assignments_in_period(start_date)
+      assignments.where(created_at: start_date..Time.current).count
+    end
+
+    def default_assignments_data
+      {
+        last_created: nil,
+        first_created: nil,
+        past7: 0,
+        past14: 0,
+        past30: 0
+      }
+    end
+  end
+end

--- a/lib/togglefy/analytics.rb
+++ b/lib/togglefy/analytics.rb
@@ -1,12 +1,43 @@
 # frozen_string_literal: true
 
+# This module provides analytics functionality for the Togglefy gem.
+# It analyzes feature usage and assignment data, offering insights such as:
+# - How many assignables have the feature enabled/disabled
+# - Percentage breakdowns
+# - Assignment activity over time
+#
+# @example
+#   analytics = Togglefy::Analytics.new('dark_mode')
+#   data = analytics.track
+#   # => [
+#   #   {
+#   #     assignable: "User",
+#   #     enabled_count: 120,
+#   #     disabled_count: 30,
+#   #     total_count: 150,
+#   #     percentage_enabled: "80.0%",
+#   #     percentage_disabled: "20.0%",
+#   #     last_created: ...,
+#   #     ...
+#   #   }
+#   # ]
 module Togglefy
   class Analytics
+    # Initializes the analytics with a feature identifier.
+    #
+    # @param identifier [String, Symbol, nil] The unique feature identifier.
     def initialize(identifier = nil)
       @identifier = identifier
       @feature = fetch_feature
     end
 
+    # Generates analytics data for the feature.
+    #
+    # @return [Array<Hash>] An array of hashes, each containing:
+    #   - assignable type
+    #   - counts of enabled/disabled
+    #   - percentages
+    #   - assignment metadata (created_at timestamps, activity windows)
     def track
       return [] unless @feature
 
@@ -15,10 +46,16 @@ module Togglefy
 
     private
 
+    # Attempts to fetch the feature based on the identifier.
+    #
+    # @return [Togglefy::Feature, nil] The feature if found, else nil.
     def fetch_feature
       Togglefy.feature(@identifier) || nil
     end
 
+    # Builds the full tracking data array.
+    #
+    # @return [Array<Hash>] Tracking data for each assignable.
     def build_tracking_data
       assignables.filter_map do |assignable|
         assignable_class = safe_constantize(assignable)
@@ -27,30 +64,28 @@ module Togglefy
         assignable_data = build_assignables_data(assignable_class)
         assignments_data = build_assignments_data
 
-        {
-          assignable: assignable,
-          total: assignable_data[:total_count],
-          enabled_count: assignable_data[:enabled_count],
-          disabled_count: assignable_data[:disabled_count],
-          percentage_enabled: assignable_data[:percentage_enabled],
-          percentage_disabled: assignable_data[:percentage_disabled],
-          first_created: assignments_data[:first_created],
-          last_created: assignments_data[:last_created],
-          past7: assignments_data[:past7],
-          past14: assignments_data[:past14],
-          past30: assignments_data[:past30]
-        }
+        [{ assignable: assignable }, assignable_data, assignments_data].reduce(:merge)
       end
     end
 
+    # Returns a list of assignable class names related to the feature.
+    #
+    # @return [Array<String>] The list of assignable types (e.g., ["User", "Admin"]).
     def assignables
       @assignables ||= assignments.map(&:assignable_type).uniq
     end
 
+    # Returns all assignments for the current feature.
+    #
+    # @return [ActiveRecord::Relation] The assignment records (enabled/disabled toggles).
     def assignments
       @assignments ||= @feature ? Togglefy::FeatureAssignment.where(feature_id: @feature.id) : []
     end
 
+    # Safely converts a string class name to a constant.
+    #
+    # @param assignable [String] The name of the assignable class.
+    # @return [Class, nil] The constantized class, or nil if invalid.
     def safe_constantize(assignable)
       assignable.constantize
     rescue NameError => e
@@ -58,8 +93,12 @@ module Togglefy
       nil
     end
 
+    # Builds metrics for how the feature is distributed across assignables.
+    #
+    # @param klass [Class] The assignable class.
+    # @return [Hash] Count and percentage breakdown.
     def build_assignables_data(klass)
-      return default_assignable_data unless klass.respond_to?(:with_features) && klass.respond_to?(:without_features)
+      return assignables_data unless klass.respond_to?(:with_features) && klass.respond_to?(:without_features)
 
       with_features = klass.with_features(@feature.id)
       without_features = klass.without_features(@feature.id)
@@ -68,50 +107,67 @@ module Togglefy
       disabled_count = without_features.count
       total_count = enabled_count + disabled_count
 
-      return default_assignable_data if total_count.zero?
+      return assignables_data if total_count.zero?
 
+      assignables_data(enabled_count, disabled_count, total_count)
+    end
+
+    # Builds a base hash of assignment data counts and percentages.
+    #
+    # @param enabled_count [Integer] Number of enabled assignments.
+    # @param disabled_count [Integer] Number of disabled assignments.
+    # @param total [Integer] Total number of assignments.
+    # @return [Hash] A data hash with counts and formatted percentages.
+    def assignables_data(enabled_count = 0, disabled_count = 0, total = 0)
       {
         enabled_count: enabled_count,
         disabled_count: disabled_count,
-        total_count: total_count,
-        percentage_enabled: calculate_percentage(enabled_count, total_count),
-        percentage_disabled: calculate_percentage(disabled_count, total_count)
+        total_count: total,
+        percentage_enabled: calculate_percentage(enabled_count, total),
+        percentage_disabled: calculate_percentage(disabled_count, total)
       }
     end
 
-    def default_assignable_data
-      {
-        enabled_count: 0,
-        disabled_count: 0,
-        total_count: 0,
-        percentage_enabled: "0.00%",
-        percentage_disabled: "0.00%"
-      }
-    end
-
+    # Calculates the percentage value based on count and total.
+    #
+    # @param count [Integer] The number of matching items (e.g., enabled assignments).
+    # @param total [Integer] The total number of items.
+    # @return [String] The percentage formatted as a string (e.g., "66.7%").
     def calculate_percentage(count, total)
       return "0.00%" if total.zero?
 
-      percentage = (count.to_f / total.to_f * 100).round(2)
+      percentage = (count.to_f / total * 100).round(2)
       "#{percentage}%"
     end
 
+    # Builds time-based metrics for feature assignment activity.
+    #
+    # @return [Hash] Assignment activity data.
     def build_assignments_data
       return default_assignments_data if assignments.empty?
 
+      # rubocop:disable Naming/VariableNumber
       {
         last_created: assignments.maximum(:created_at),
         first_created: assignments.minimum(:created_at),
-        past7: count_assignments_in_period(7.days.ago),
-        past14: count_assignments_in_period(14.days.ago),
-        past30: count_assignments_in_period(30.days.ago)
+        past_7: count_assignments_in_period(7.days.ago),
+        past_14: count_assignments_in_period(14.days.ago),
+        past_30: count_assignments_in_period(30.days.ago)
       }
+      # rubocop:enable Naming/VariableNumber
     end
 
+    # Counts how many assignments occurred since a given date.
+    #
+    # @param start_date [Date, Time] The starting date for the activity window.
+    # @return [Integer] The number of assignments created since that date.
     def count_assignments_in_period(start_date)
       assignments.where(created_at: start_date..Time.current).count
     end
 
+    # Returns default assignment tracking data for a feature.
+    #
+    # @return [Hash] A hash with default values for assignment metrics.
     def default_assignments_data
       {
         last_created: nil,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,8 @@ RSpec.configure do |config|
   # config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/togglefy/analytics_spec.rb
+++ b/spec/togglefy/analytics_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Togglefy::Analytics do
 
         expect(result[:enabled_count]).to eq(2)
         expect(result[:disabled_count]).to eq(3)
-        expect(result[:total_count]).to eq(5)
+        expect(result[:total]).to eq(5)
         expect(result[:percentage_enabled]).to eq("40.0%")
         expect(result[:percentage_disabled]).to eq("60.0%")
       end
@@ -98,7 +98,7 @@ RSpec.describe Togglefy::Analytics do
 
           expect(result[:enabled_count]).to eq(0)
           expect(result[:disabled_count]).to eq(0)
-          expect(result[:total_count]).to eq(0)
+          expect(result[:total]).to eq(0)
           expect(result[:percentage_enabled]).to eq("0.00%")
           expect(result[:percentage_disabled]).to eq("0.00%")
         end
@@ -107,9 +107,9 @@ RSpec.describe Togglefy::Analytics do
 
     describe "#build_assignments_data" do
       let(:mock_assignments) { double("ActiveRecord::Relation") }
-      let(:past7_assignments) { double("Relation", count: 3) }
-      let(:past14_assignments) { double("Relation", count: 7) }
-      let(:past30_assignments) { double("Relation", count: 15) }
+      let(:past_7_assignments) { double("Relation", count: 3) }
+      let(:past_14_assignments) { double("Relation", count: 7) }
+      let(:past_30_assignments) { double("Relation", count: 15) }
 
       before do
         travel_to Time.new(2024, 12, 4, 16, 30) # Mon, 04 Dec 2024 16:30:00
@@ -121,13 +121,13 @@ RSpec.describe Togglefy::Analytics do
 
         allow(mock_assignments).to receive(:where)
           .with(created_at: 7.days.ago..Time.current)
-          .and_return(past7_assignments)
+          .and_return(past_7_assignments)
         allow(mock_assignments).to receive(:where)
           .with(created_at: 14.days.ago..Time.current)
-          .and_return(past14_assignments)
+          .and_return(past_14_assignments)
         allow(mock_assignments).to receive(:where)
           .with(created_at: 30.days.ago..Time.current)
-          .and_return(past30_assignments)
+          .and_return(past_30_assignments)
       end
 
       it "builds assignments data correctly" do
@@ -135,9 +135,11 @@ RSpec.describe Togglefy::Analytics do
 
         expect(result[:last_created]).to eq(1.day.ago)
         expect(result[:first_created]).to eq(30.days.ago)
-        expect(result[:past7]).to eq(15)
-        expect(result[:past14]).to eq(15)
-        expect(result[:past30]).to eq(15)
+        # rubocop:disable Naming/VariableNumber
+        expect(result[:past_7]).to eq(15)
+        expect(result[:past_14]).to eq(15)
+        expect(result[:past_30]).to eq(15)
+        # rubocop:enable Naming/VariableNumber
       end
     end
   end

--- a/spec/togglefy/analytics_spec.rb
+++ b/spec/togglefy/analytics_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Togglefy::Analytics do
+  let!(:feature_identifier) { :test_feature }
+  let!(:feature) { Togglefy::Feature.create!(name: "Test Feature", identifier: feature_identifier, status: :active) }
+  let!(:analytics) { described_class.new(feature_identifier) }
+  let!(:user_one) { User.create! }
+  let!(:user_two) { User.create! }
+  let!(:user_class) { User }
+
+  describe "#initialize" do
+    context "with valid identifier" do
+      it "sets the identifier and fetches the feature" do
+        expect(Togglefy).to receive(:feature).with(feature_identifier)
+        described_class.new(feature_identifier)
+      end
+    end
+  end
+
+  describe "#track" do
+    before do
+      user_one.add_feature(feature_identifier)
+      user_two.add_feature(feature_identifier)
+      3.times { User.create! }
+    end
+
+    context "when feature exists" do
+      it "returns tracking data consistent" do
+        result = analytics.track
+        expect(result).to be_an(Array)
+        expect(result.first).to be_an(Hash)
+      end
+
+      it "returns tracking data correctly" do
+        result = analytics.track
+        user_tracking = result.first
+
+        expect(user_tracking[:assignable]).to eq("User")
+        expect(user_tracking[:total]).to eq(5)
+        expect(user_tracking[:enabled_count]).to eq(2)
+        expect(user_tracking[:disabled_count]).to eq(3)
+        expect(user_tracking[:percentage_enabled]).to eq("40.0%")
+        expect(user_tracking[:percentage_disabled]).to eq("60.0%")
+        expect(user_tracking[:last_created]).to be_an(Time)
+        expect(user_tracking[:first_created]).to be_an(Time)
+        expect(user_tracking[:past7]).to eq(2)
+        expect(user_tracking[:past14]).to eq(2)
+        expect(user_tracking[:past30]).to eq(2)
+      end
+    end
+  end
+
+  describe "private methods" do
+    describe "#safe_constantize" do
+      it "successfully constantizes valid class names" do
+        result = analytics.send(:safe_constantize, "User")
+        expect(result).to eq(user_class)
+      end
+
+      it "handles invalid class names gracefully" do
+        allow(Rails.logger).to receive(:warn)
+
+        result = analytics.send(:safe_constantize, "InvalidClass")
+        expect(result).to be_nil
+        expect(Rails.logger).to have_received(:warn).with(/Invalid assignable class: InvalidClass/)
+      end
+    end
+
+    describe "#build_assignables_data" do
+      before do
+        user_one.add_feature(feature_identifier)
+        user_two.add_feature(feature_identifier)
+        3.times { User.create! }
+      end
+
+      it "builds assignable data correctly" do
+        result = analytics.send(:build_assignables_data, user_class)
+
+        expect(result[:enabled_count]).to eq(2)
+        expect(result[:disabled_count]).to eq(3)
+        expect(result[:total_count]).to eq(5)
+        expect(result[:percentage_enabled]).to eq("40.0%")
+        expect(result[:percentage_disabled]).to eq("60.0%")
+      end
+
+      context "when assignable doesnt respond to Togglefy methods" do
+        before do
+          allow(user_class).to receive(:respond_to?).with(:with_features).and_return(false)
+        end
+
+        it "returns default assignable data" do
+          result = analytics.send(:build_assignables_data, user_class)
+
+          expect(result[:enabled_count]).to eq(0)
+          expect(result[:disabled_count]).to eq(0)
+          expect(result[:total_count]).to eq(0)
+          expect(result[:percentage_enabled]).to eq("0.00%")
+          expect(result[:percentage_disabled]).to eq("0.00%")
+        end
+      end
+    end
+
+    describe "#build_assignments_data" do
+      let(:mock_assignments) { double("ActiveRecord::Relation") }
+      let(:past7_assignments) { double("Relation", count: 3) }
+      let(:past14_assignments) { double("Relation", count: 7) }
+      let(:past30_assignments) { double("Relation", count: 15) }
+
+      before do
+        travel_to Time.new(2024, 12, 4, 16, 30) # Mon, 04 Dec 2024 16:30:00
+
+        allow(analytics).to receive(:assignments).and_return(mock_assignments)
+        allow(mock_assignments).to receive(:empty?).and_return(false)
+        allow(mock_assignments).to receive(:maximum).with(:created_at).and_return(1.day.ago)
+        allow(mock_assignments).to receive(:minimum).with(:created_at).and_return(30.days.ago)
+
+        allow(mock_assignments).to receive(:where)
+          .with(created_at: 7.days.ago..Time.current)
+          .and_return(past7_assignments)
+        allow(mock_assignments).to receive(:where)
+          .with(created_at: 14.days.ago..Time.current)
+          .and_return(past14_assignments)
+        allow(mock_assignments).to receive(:where)
+          .with(created_at: 30.days.ago..Time.current)
+          .and_return(past30_assignments)
+      end
+
+      it "builds assignments data correctly" do
+        result = analytics.send(:build_assignments_data)
+
+        expect(result[:last_created]).to eq(1.day.ago)
+        expect(result[:first_created]).to eq(30.days.ago)
+        expect(result[:past7]).to eq(15)
+        expect(result[:past14]).to eq(15)
+        expect(result[:past30]).to eq(15)
+      end
+    end
+  end
+end

--- a/spec/togglefy/analytics_spec.rb
+++ b/spec/togglefy/analytics_spec.rb
@@ -46,9 +46,11 @@ RSpec.describe Togglefy::Analytics do
         expect(user_tracking[:percentage_disabled]).to eq("60.0%")
         expect(user_tracking[:last_created]).to be_an(Time)
         expect(user_tracking[:first_created]).to be_an(Time)
-        expect(user_tracking[:past7]).to eq(2)
-        expect(user_tracking[:past14]).to eq(2)
-        expect(user_tracking[:past30]).to eq(2)
+        # rubocop:disable Naming/VariableNumber
+        expect(user_tracking[:past_7]).to eq(2)
+        expect(user_tracking[:past_14]).to eq(2)
+        expect(user_tracking[:past_30]).to eq(2)
+        # rubocop:enable Naming/VariableNumber
       end
     end
   end

--- a/spec/togglefy/analytics_spec.rb
+++ b/spec/togglefy/analytics_spec.rb
@@ -2,6 +2,7 @@
 
 require "rails_helper"
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe Togglefy::Analytics do
   let!(:feature_identifier) { :test_feature }
   let!(:feature) { Togglefy::Feature.create!(name: "Test Feature", identifier: feature_identifier, status: :active) }
@@ -139,3 +140,4 @@ RSpec.describe Togglefy::Analytics do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
# Context

A first version for tracking Analytics for a single feature, passing on the identifier as params.
This was discussed [here in the previous issue create](https://github.com/azeveco/Togglefy/issues/21)

Discussions in the issue got obsolete, as we decided to move further with a first version tracking a specific feature passing its identifier as a parameter.

See more info on analytics usage below in Resolution

# Resolution

+ Added the Togglefy method `analytics_for`, that calls our specific Analytics class to track a feature
```ruby
# in lib/togglefy.rb
...
Togglefy.analytics_for(:arachnid_super_power)
...
```

Analytics class basically reads the identifier passed as parameter, initializes with the accordingly feature, and tries to track it.
The found system found Assignables will be arranged into an Array of Hashes.

Each Hash represent the found Assignable and its tracked data, something like that:

```ruby
[{assignable: "User",
  total: 4,
  enabled_count: 2,
  disabled_count: 2,
  percentage_enabled: "50.0%",
  percentage_disabled: "50.0%",
  first_created: 2025-04-21 01:43:28.266664000 UTC +00:00,
  last_created: 2025-05-21 19:18:37.772172000 UTC +00:00,
  past7: 1,
  past14: 1,
  past30: 2}]
```

# Impacted processes/locations

- Changed `rails_helper.rb` to use Rails native time travel

# References

[Issue 21: Feature statistics/analytics](https://github.com/azeveco/Togglefy/issues/21)